### PR TITLE
[codex] Support VS Code 1.118 shared recent storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,21 +34,40 @@ bin:
 # Install everything
 install: install.plugin install.bin
 
+# Uninstall everything installed by `make install`
+uninstall: uninstall.plugin uninstall.bin
+
 # Just install the plugin
 install.plugin:
 	install -Dt $(DESTDIR)$(pluginsdir) $(CARGO_RELEASE_DIR)/$(LIBNAME)
+
+# Just uninstall the plugin
+uninstall.plugin:
+	$(RM) $(DESTDIR)$(pluginsdir)/$(LIBNAME)
 
 # Just install the binary
 install.bin:
 	install -Dt $(DESTDIR)$(bindir) $(CARGO_RELEASE_DIR)/$(BINNAME)
 
+# Just uninstall the binary
+uninstall.bin:
+	$(RM) $(DESTDIR)$(bindir)/$(BINNAME)
+
 install.doc:
 	install -Dt $(DESTDIR)$(docdir) README.md
+
+uninstall.doc:
+	$(RM) $(DESTDIR)$(docdir)/README.md
+	-rmdir $(DESTDIR)$(docdir)
 
 install.licenses:
 	install -Dt $(DESTDIR)$(licensesdir) LICENSE
 
+uninstall.licenses:
+	$(RM) $(DESTDIR)$(licensesdir)/LICENSE
+	-rmdir $(DESTDIR)$(licensesdir)
+
 clean:
 	$(CARGO) clean
 
-.PHONY: all plugin bin install install.plugin install.bin install.doc install.licences clean
+.PHONY: all plugin bin install install.plugin install.bin install.doc install.licenses uninstall uninstall.plugin uninstall.bin uninstall.doc uninstall.licenses clean

--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ When an item is selected, press:
 
 :warning: Item deletion works by updating the recent items list in VSCode's state database. Do it at your own risk. Please use this feature when VSCode is closed, otherwise your changes may be overwritten.
 
-VS Code 1.118 and newer store the recent folders/files list in application shared storage so it can be shared with the VS Code Agents app. On Linux, stable VS Code uses `~/.vscode-shared/sharedStorage/state.vscdb` for that shared database. Older VS Code versions use `~/.config/Code/User/globalStorage/state.vscdb` instead. This tool tries the shared storage location first and falls back to the legacy global storage database.
-
 ### As a command line tool
 If you prefer something other than Rofi to select your entry, we also provide the `vscode-recent` command that simply writes out the paths line by line. You can then pair it with your favourite selection tool, like [dmenu](https://tools.suckless.org/dmenu/) or [fzf](https://github.com/junegunn/fz).
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ make plugin
 sudo make install.plugin
 ```
 
+To uninstall files installed from source, run the matching uninstall target:
+```sh
+# Binary and plugin
+sudo make uninstall
+
+# Binary only
+sudo make uninstall.bin
+
+# Plugin only
+sudo make uninstall.plugin
+```
+
 ## Usage
 
 ### As a Rofi mode

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ When an item is selected, press:
 
 :warning: Item deletion works by updating the recent items list in VSCode's state database. Do it at your own risk. Please use this feature when VSCode is closed, otherwise your changes may be overwritten.
 
+VS Code 1.118 and newer store the recent folders/files list in application shared storage so it can be shared with the VS Code Agents app. On Linux, stable VS Code uses `~/.vscode-shared/sharedStorage/state.vscdb` for that shared database. Older VS Code versions use `~/.config/Code/User/globalStorage/state.vscdb` instead. This tool tries the shared storage location first and falls back to the legacy global storage database.
+
 ### As a command line tool
 If you prefer something other than Rofi to select your entry, we also provide the `vscode-recent` command that simply writes out the paths line by line. You can then pair it with your favourite selection tool, like [dmenu](https://tools.suckless.org/dmenu/) or [fzf](https://github.com/junegunn/fz).
 

--- a/src/vscode.rs
+++ b/src/vscode.rs
@@ -20,13 +20,6 @@ const SCHEME_FILE: &str = "file";
 const SCHEME_REMOTE: &str = "vscode-remote";
 #[allow(dead_code)]
 const SCHEME_VIRTUAL: &str = "vscode-vfs";
-const VSCDB_HISTORY_KEY: &str = "history.recentlyOpenedPathsList";
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct StateDbPath {
-    scope: &'static str,
-    path: PathBuf,
-}
 
 /// One of the possible VSCode flavors
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -48,8 +41,23 @@ impl Flavor {
         }
     }
 
-    /// Path to the configuration directory of the flavor, if it exists
-    pub fn config_dir(&self) -> Option<PathBuf> {
+    /// Path to the VSCode state database file, if it exists
+    pub fn history_state_db_path(&self) -> Option<PathBuf> {
+        // First check shared storage paths (highest priority)
+        let subdir = match self {
+            Self::Code => ".vscode-shared",
+            Self::CodeInsiders => ".vscode-insiders-shared",
+            Self::CodeOSS => ".vscode-oss-shared",
+            Self::VSCodium => ".vscodium-shared",
+        };
+        let db_path = dirs::home_dir()
+            .map(|p| p.join(subdir).join("sharedStorage").join("state.vscdb"))
+            .filter(|p| p.exists());
+        if db_path.is_some() {
+            return db_path;
+        }
+
+        // Then check legacy global storage path
         let subdir = match self {
             Self::Code => "Code",
             Self::CodeInsiders => "Code - Insiders",
@@ -57,38 +65,20 @@ impl Flavor {
             Self::VSCodium => "VSCodium",
         };
         dirs::config_dir()
-            .map(|mut p| {
-                p.push(subdir);
-                p
+            .map(|p| {
+                p.join(subdir)
+                    .join("User")
+                    .join("globalStorage")
+                    .join("state.vscdb")
             })
             .filter(|p| p.exists())
-    }
-
-    fn shared_data_folder_names(&self) -> &'static [&'static str] {
-        match self {
-            Self::Code => &[".vscode-shared"],
-            Self::CodeInsiders => &[".vscode-insiders-shared"],
-            Self::CodeOSS => &[".vscode-oss-shared"],
-            Self::VSCodium => &[".vscode-oss-shared", ".vscodium-shared"],
-        }
-    }
-
-    fn shared_state_db_paths(&self) -> Vec<PathBuf> {
-        let Some(home) = dirs::home_dir() else {
-            return Vec::new();
-        };
-
-        self.shared_data_folder_names()
-            .iter()
-            .map(|folder| home.join(folder).join("sharedStorage").join("state.vscdb"))
-            .collect()
     }
 
     /// Tries to detect the preferred flavor
     ///
     /// It returns the first flavor for which it can find both:
     /// - an executable in `$PATH`
-    /// - a configuration directory
+    /// - a state database
     pub fn detect() -> Option<&'static Self> {
         let candidates = &[
             Self::VSCodium,
@@ -98,7 +88,7 @@ impl Flavor {
         ];
         candidates
             .iter()
-            .find(|d| which(d.cmd()).ok().and(d.config_dir()).is_some())
+            .find(|d| which(d.cmd()).ok().and(d.history_state_db_path()).is_some())
     }
 
     /// Opens a recent item
@@ -173,10 +163,7 @@ impl FromStr for Flavor {
 /// - [Workspaces History Main Service](https://github.com/microsoft/vscode/blob/main/src/vs/platform/workspaces/electron-main/workspacesHistoryMainService.ts)
 /// - [workspaces common definitions](https://github.com/microsoft/vscode/blob/main/src/vs/platform/workspaces/common/workspaces.ts)
 pub mod workspaces {
-    use super::{
-        history_state_db_paths, open_history_state_db, tildify, Flavor, SCHEME_FILE,
-        VSCDB_HISTORY_KEY,
-    };
+    use super::{open_state_db, tildify, Flavor, SCHEME_FILE};
     use std::{
         borrow::Cow,
         fmt::{self, Display},
@@ -188,6 +175,8 @@ pub mod workspaces {
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
     use url::Url;
+
+    const VSCDB_HISTORY_KEY: &str = "history.recentlyOpenedPathsList";
 
     /// Identifies a multi-root Workspace
     ///
@@ -456,26 +445,13 @@ pub mod workspaces {
     /// Workspaces that fail to deserialize to known data structures will be ignored.
     ///
     /// The entries will be looked up from VSCode's state database.
-    /// VSCode 1.118+ uses application shared storage; older releases use global storage inside the given `config_dir`.
-    fn get_history_entries(
-        config_dir: &Path,
-        flavor: &Flavor,
-        local_only: bool,
-    ) -> anyhow::Result<Vec<Recent>> {
-        let candidates = history_state_db_paths(config_dir, flavor);
-        get_history_entries_from_state_db_paths(&candidates, local_only)
-    }
-
-    fn get_history_entries_from_state_db_paths(
-        candidates: &[super::StateDbPath],
-        local_only: bool,
-    ) -> anyhow::Result<Vec<Recent>> {
+    fn get_history_entries(db_path: &Path, local_only: bool) -> anyhow::Result<Vec<Recent>> {
         // Reference from `restoreRecentlyOpened` in
         // https://github.com/microsoft/vscode/blob/main/src/vs/platform/workspaces/common/workspaces.ts
 
         // Open the DB
         let open_flags = Some(OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX);
-        let conn = open_history_state_db(candidates, open_flags, true)?;
+        let conn = open_state_db(db_path, open_flags)?;
 
         // Retrieve the JSON value of the property
         let res: Value = conn
@@ -510,22 +486,10 @@ pub mod workspaces {
     ///
     /// Performs the reverse operation of [get_history_entries],
     /// see its documentation for details.
-    fn store_history_entries(
-        config_dir: &Path,
-        flavor: &Flavor,
-        entries: &[Recent],
-    ) -> anyhow::Result<()> {
-        let candidates = history_state_db_paths(config_dir, flavor);
-        store_history_entries_to_state_db_paths(&candidates, entries)
-    }
-
-    fn store_history_entries_to_state_db_paths(
-        candidates: &[super::StateDbPath],
-        entries: &[Recent],
-    ) -> anyhow::Result<()> {
+    fn store_history_entries(db_path: &Path, entries: &[Recent]) -> anyhow::Result<()> {
         // Open DB
         let open_flags = Some(OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX);
-        let conn = open_history_state_db(candidates, open_flags, false)?;
+        let conn = open_state_db(db_path, open_flags)?;
 
         // Serialize to JSON
         let value = json!({
@@ -545,7 +509,6 @@ pub mod workspaces {
     ///
     /// This function will retrieve the items from the state storage of the
     /// given `flavor`. The items are sorted from the most to the least recent.
-    /// VSCode 1.118+ uses application shared storage; older releases use global storage.
     ///
     /// If `local_only` is set, recent items for which [Recent::is_local()] does not hold will be discarded.
     /// This is useful if you need to open the items by path.
@@ -558,13 +521,10 @@ pub mod workspaces {
         flavor: &Flavor,
         local_only: bool,
     ) -> anyhow::Result<Vec<Recent>> {
-        let config_dir = flavor.config_dir().ok_or_else(|| {
-            anyhow!(
-                "Could not find configuration directory for \"{:?}\"",
-                flavor
-            )
-        })?;
-        get_history_entries(&config_dir, flavor, local_only)
+        let db_path = flavor
+            .history_state_db_path()
+            .ok_or_else(|| anyhow!("Could not find state database for \"{:?}\"", flavor))?;
+        get_history_entries(&db_path, local_only)
     }
 
     /// Store the workspaces into VSCode's state
@@ -572,14 +532,10 @@ pub mod workspaces {
     /// Performs the reverse operation of [recently_opened_from_storage],
     /// see its documentation for details.
     pub fn store_recently_opened(flavor: &Flavor, entries: &[Recent]) -> anyhow::Result<()> {
-        let config_dir = flavor.config_dir().ok_or_else(|| {
-            anyhow!(
-                "Could not find configuration directory for \"{:?}\"",
-                flavor
-            )
-        })?;
-
-        store_history_entries(&config_dir, flavor, entries)
+        let db_path = flavor
+            .history_state_db_path()
+            .ok_or_else(|| anyhow!("Could not find state database for \"{:?}\"", flavor))?;
+        store_history_entries(&db_path, entries)
     }
 
     #[cfg(test)]
@@ -594,11 +550,9 @@ pub mod workspaces {
         use serde_json::json;
         use url::Url;
 
-        use super::{
-            get_history_entries_from_state_db_paths, store_history_entries_to_state_db_paths,
-            Recent,
-        };
-        use crate::vscode::{StateDbPath, VSCDB_HISTORY_KEY};
+        use crate::vscode::workspaces::{get_history_entries, store_history_entries};
+
+        use super::{Recent, VSCDB_HISTORY_KEY};
 
         fn temp_dir(name: &str) -> PathBuf {
             let timestamp = SystemTime::now()
@@ -611,10 +565,6 @@ pub mod workspaces {
             ));
             fs::create_dir_all(&path).expect("could not create temp dir");
             path
-        }
-
-        fn candidate(scope: &'static str, path: PathBuf) -> StateDbPath {
-            StateDbPath { scope, path }
         }
 
         fn create_history_db(path: &Path, value: Option<serde_json::Value>) {
@@ -640,7 +590,6 @@ pub mod workspaces {
         fn reads_recent_history_from_application_shared_storage_first() {
             let root = temp_dir("shared-first");
             let shared = root.join("shared").join("state.vscdb");
-            let legacy = root.join("legacy").join("state.vscdb");
 
             create_history_db(
                 &shared,
@@ -651,24 +600,8 @@ pub mod workspaces {
                     }]
                 })),
             );
-            create_history_db(
-                &legacy,
-                Some(json!({
-                    "entries": [{
-                        "folderUri": "file:///tmp/legacy-project",
-                        "label": "Legacy Project"
-                    }]
-                })),
-            );
 
-            let entries = get_history_entries_from_state_db_paths(
-                &[
-                    candidate("application shared storage", shared),
-                    candidate("legacy global storage", legacy),
-                ],
-                false,
-            )
-            .expect("expected entries");
+            let entries = get_history_entries(&shared, false).expect("expected entries");
 
             assert_eq!(entries.len(), 1);
             assert_eq!(entries[0].label().unwrap(), "Shared Project");
@@ -677,53 +610,11 @@ pub mod workspaces {
         }
 
         #[test]
-        fn falls_back_to_legacy_storage_when_shared_key_is_missing() {
-            let root = temp_dir("legacy-fallback");
-            let shared = root.join("shared").join("state.vscdb");
-            let legacy = root.join("legacy").join("state.vscdb");
-
-            create_history_db(&shared, None);
-            create_history_db(
-                &legacy,
-                Some(json!({
-                    "entries": [{
-                        "folderUri": "file:///tmp/legacy-project",
-                        "label": "Legacy Project"
-                    }]
-                })),
-            );
-
-            let entries = get_history_entries_from_state_db_paths(
-                &[
-                    candidate("application shared storage", shared),
-                    candidate("legacy global storage", legacy),
-                ],
-                false,
-            )
-            .expect("expected legacy fallback entries");
-
-            assert_eq!(entries.len(), 1);
-            assert_eq!(entries[0].label().unwrap(), "Legacy Project");
-
-            fs::remove_dir_all(root).ok();
-        }
-
-        #[test]
         fn stores_recent_history_in_shared_storage_with_upsert() {
             let root = temp_dir("shared-upsert");
             let shared = root.join("shared").join("state.vscdb");
-            let legacy = root.join("legacy").join("state.vscdb");
 
             create_history_db(&shared, None);
-            create_history_db(
-                &legacy,
-                Some(json!({
-                    "entries": [{
-                        "folderUri": "file:///tmp/legacy-project",
-                        "label": "Legacy Project"
-                    }]
-                })),
-            );
 
             let recent: Recent = serde_json::from_value(json!({
                 "folderUri": "file:///tmp/new-project",
@@ -731,14 +622,7 @@ pub mod workspaces {
             }))
             .expect("could not deserialize recent");
 
-            store_history_entries_to_state_db_paths(
-                &[
-                    candidate("application shared storage", shared.clone()),
-                    candidate("legacy global storage", legacy),
-                ],
-                &[recent],
-            )
-            .expect("could not store entries");
+            store_history_entries(&shared, &[recent]).expect("could not store entries");
 
             let conn = Connection::open(shared).expect("could not reopen shared db");
             let stored: serde_json::Value = conn
@@ -844,108 +728,10 @@ pub mod workspaces {
     }
 }
 
-fn history_state_db_paths(config_dir: &Path, flavor: &Flavor) -> Vec<StateDbPath> {
-    let mut paths = flavor
-        .shared_state_db_paths()
-        .into_iter()
-        .map(|path| StateDbPath {
-            scope: "application shared storage",
-            path,
-        })
-        .collect::<Vec<_>>();
-
-    paths.push(StateDbPath {
-        scope: "legacy global storage",
-        path: config_dir
-            .join("User")
-            .join("globalStorage")
-            .join("state.vscdb"),
-    });
-
-    paths
-}
-
-fn open_history_state_db(
-    candidates: &[StateDbPath],
-    open_flags: Option<OpenFlags>,
-    require_history_key: bool,
-) -> anyhow::Result<Connection> {
+fn open_state_db(db_path: &Path, open_flags: Option<OpenFlags>) -> anyhow::Result<Connection> {
     let open_flags = open_flags.unwrap_or_default();
-    let mut attempts = Vec::new();
-
-    for candidate in candidates {
-        let conn = match Connection::open_with_flags(&candidate.path, open_flags) {
-            Ok(conn) => conn,
-            Err(error) => {
-                attempts.push(format!(
-                    "{} {:?}: could not open ({error})",
-                    candidate.scope, candidate.path
-                ));
-                continue;
-            }
-        };
-
-        match item_table_exists(&conn) {
-            Ok(true) => {}
-            Ok(false) => {
-                attempts.push(format!(
-                    "{} {:?}: ItemTable not found",
-                    candidate.scope, candidate.path
-                ));
-                continue;
-            }
-            Err(error) => {
-                attempts.push(format!(
-                    "{} {:?}: could not inspect schema ({error})",
-                    candidate.scope, candidate.path
-                ));
-                continue;
-            }
-        }
-
-        if require_history_key {
-            match history_key_exists(&conn) {
-                Ok(true) => {}
-                Ok(false) => {
-                    attempts.push(format!(
-                        "{} {:?}: key {VSCDB_HISTORY_KEY:?} not found",
-                        candidate.scope, candidate.path
-                    ));
-                    continue;
-                }
-                Err(error) => {
-                    attempts.push(format!(
-                        "{} {:?}: could not inspect history key ({error})",
-                        candidate.scope, candidate.path
-                    ));
-                    continue;
-                }
-            }
-        }
-
-        return Ok(conn);
-    }
-
-    Err(anyhow!(
-        "Could not open VSCode history state DB. Tried: {}",
-        attempts.join("; ")
-    ))
-}
-
-fn item_table_exists(conn: &Connection) -> rusqlite::Result<bool> {
-    conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'ItemTable')",
-        [],
-        |row| row.get::<_, bool>(0),
-    )
-}
-
-fn history_key_exists(conn: &Connection) -> rusqlite::Result<bool> {
-    conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM ItemTable WHERE key = (?1))",
-        [VSCDB_HISTORY_KEY],
-        |row| row.get::<_, bool>(0),
-    )
+    Connection::open_with_flags(db_path, open_flags)
+        .with_context(|| format!("Could not open database {:?}", &db_path))
 }
 
 /// Replace the home directory prefix of `path` with `~`

--- a/src/vscode.rs
+++ b/src/vscode.rs
@@ -20,6 +20,13 @@ const SCHEME_FILE: &str = "file";
 const SCHEME_REMOTE: &str = "vscode-remote";
 #[allow(dead_code)]
 const SCHEME_VIRTUAL: &str = "vscode-vfs";
+const VSCDB_HISTORY_KEY: &str = "history.recentlyOpenedPathsList";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StateDbPath {
+    scope: &'static str,
+    path: PathBuf,
+}
 
 /// One of the possible VSCode flavors
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -55,6 +62,26 @@ impl Flavor {
                 p
             })
             .filter(|p| p.exists())
+    }
+
+    fn shared_data_folder_names(&self) -> &'static [&'static str] {
+        match self {
+            Self::Code => &[".vscode-shared"],
+            Self::CodeInsiders => &[".vscode-insiders-shared"],
+            Self::CodeOSS => &[".vscode-oss-shared"],
+            Self::VSCodium => &[".vscode-oss-shared", ".vscodium-shared"],
+        }
+    }
+
+    fn shared_state_db_paths(&self) -> Vec<PathBuf> {
+        let Some(home) = dirs::home_dir() else {
+            return Vec::new();
+        };
+
+        self.shared_data_folder_names()
+            .iter()
+            .map(|folder| home.join(folder).join("sharedStorage").join("state.vscdb"))
+            .collect()
     }
 
     /// Tries to detect the preferred flavor
@@ -146,7 +173,10 @@ impl FromStr for Flavor {
 /// - [Workspaces History Main Service](https://github.com/microsoft/vscode/blob/main/src/vs/platform/workspaces/electron-main/workspacesHistoryMainService.ts)
 /// - [workspaces common definitions](https://github.com/microsoft/vscode/blob/main/src/vs/platform/workspaces/common/workspaces.ts)
 pub mod workspaces {
-    use super::{open_state_db, tildify, Flavor, SCHEME_FILE};
+    use super::{
+        history_state_db_paths, open_history_state_db, tildify, Flavor, SCHEME_FILE,
+        VSCDB_HISTORY_KEY,
+    };
     use std::{
         borrow::Cow,
         fmt::{self, Display},
@@ -158,8 +188,6 @@ pub mod workspaces {
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
     use url::Url;
-
-    const VSCDB_HISTORY_KEY: &str = "history.recentlyOpenedPathsList";
 
     /// Identifies a multi-root Workspace
     ///
@@ -427,14 +455,27 @@ pub mod workspaces {
     /// # Warning
     /// Workspaces that fail to deserialize to known data structures will be ignored.
     ///
-    /// The entries will be looked up from VSCode's global storage inside the given `config_dir` configuration directory
-    fn get_history_entries(config_dir: &Path, local_only: bool) -> anyhow::Result<Vec<Recent>> {
+    /// The entries will be looked up from VSCode's state database.
+    /// VSCode 1.118+ uses application shared storage; older releases use global storage inside the given `config_dir`.
+    fn get_history_entries(
+        config_dir: &Path,
+        flavor: &Flavor,
+        local_only: bool,
+    ) -> anyhow::Result<Vec<Recent>> {
+        let candidates = history_state_db_paths(config_dir, flavor);
+        get_history_entries_from_state_db_paths(&candidates, local_only)
+    }
+
+    fn get_history_entries_from_state_db_paths(
+        candidates: &[super::StateDbPath],
+        local_only: bool,
+    ) -> anyhow::Result<Vec<Recent>> {
         // Reference from `restoreRecentlyOpened` in
         // https://github.com/microsoft/vscode/blob/main/src/vs/platform/workspaces/common/workspaces.ts
 
         // Open the DB
         let open_flags = Some(OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX);
-        let conn = open_state_db(config_dir, open_flags)?;
+        let conn = open_history_state_db(candidates, open_flags, true)?;
 
         // Retrieve the JSON value of the property
         let res: Value = conn
@@ -469,10 +510,22 @@ pub mod workspaces {
     ///
     /// Performs the reverse operation of [get_history_entries],
     /// see its documentation for details.
-    fn store_history_entries(config_dir: &Path, entries: &[Recent]) -> anyhow::Result<()> {
+    fn store_history_entries(
+        config_dir: &Path,
+        flavor: &Flavor,
+        entries: &[Recent],
+    ) -> anyhow::Result<()> {
+        let candidates = history_state_db_paths(config_dir, flavor);
+        store_history_entries_to_state_db_paths(&candidates, entries)
+    }
+
+    fn store_history_entries_to_state_db_paths(
+        candidates: &[super::StateDbPath],
+        entries: &[Recent],
+    ) -> anyhow::Result<()> {
         // Open DB
         let open_flags = Some(OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX);
-        let conn = open_state_db(config_dir, open_flags)?;
+        let conn = open_history_state_db(candidates, open_flags, false)?;
 
         // Serialize to JSON
         let value = json!({
@@ -481,7 +534,7 @@ pub mod workspaces {
 
         // Update DB
         conn.execute(
-            "UPDATE ItemTable SET value = (?2) WHERE key = (?1)",
+            "INSERT OR REPLACE INTO ItemTable (key, value) VALUES (?1, ?2)",
             params![VSCDB_HISTORY_KEY, value],
         )
         .with_context(|| "Could not update state in DB")
@@ -490,8 +543,9 @@ pub mod workspaces {
 
     /// Get recently opened workspaces, files and folders
     ///
-    /// This function will retrieve the items from the _global storage_ of the
-    /// given `flavor`. The items are sorted from the most to the least recent
+    /// This function will retrieve the items from the state storage of the
+    /// given `flavor`. The items are sorted from the most to the least recent.
+    /// VSCode 1.118+ uses application shared storage; older releases use global storage.
     ///
     /// If `local_only` is set, recent items for which [Recent::is_local()] does not hold will be discarded.
     /// This is useful if you need to open the items by path.
@@ -499,7 +553,7 @@ pub mod workspaces {
     /// # Warning
     /// Workspaces that fail to deserialize to known data structures will be ignored.
     ///
-    /// The entries will be looked up from VSCode's global storage
+    /// The entries will be looked up from VSCode's state database.
     pub fn recently_opened_from_storage(
         flavor: &Flavor,
         local_only: bool,
@@ -510,7 +564,7 @@ pub mod workspaces {
                 flavor
             )
         })?;
-        get_history_entries(&config_dir, local_only)
+        get_history_entries(&config_dir, flavor, local_only)
     }
 
     /// Store the workspaces into VSCode's state
@@ -525,17 +579,180 @@ pub mod workspaces {
             )
         })?;
 
-        store_history_entries(&config_dir, entries)
+        store_history_entries(&config_dir, flavor, entries)
     }
 
     #[cfg(test)]
     mod tests {
-        use std::path::Path;
+        use std::{
+            fs,
+            path::{Path, PathBuf},
+            time::{SystemTime, UNIX_EPOCH},
+        };
 
+        use rusqlite::{params, Connection};
         use serde_json::json;
         use url::Url;
 
-        use super::Recent;
+        use super::{
+            get_history_entries_from_state_db_paths, store_history_entries_to_state_db_paths,
+            Recent,
+        };
+        use crate::vscode::{StateDbPath, VSCDB_HISTORY_KEY};
+
+        fn temp_dir(name: &str) -> PathBuf {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time went backwards")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "rofi-vscode-mode-{name}-{}-{timestamp}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("could not create temp dir");
+            path
+        }
+
+        fn candidate(scope: &'static str, path: PathBuf) -> StateDbPath {
+            StateDbPath { scope, path }
+        }
+
+        fn create_history_db(path: &Path, value: Option<serde_json::Value>) {
+            fs::create_dir_all(path.parent().expect("db path should have parent"))
+                .expect("could not create db parent");
+            let conn = Connection::open(path).expect("could not create state db");
+            conn.execute(
+                "CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)",
+                [],
+            )
+            .expect("could not create ItemTable");
+
+            if let Some(value) = value {
+                conn.execute(
+                    "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+                    params![VSCDB_HISTORY_KEY, value],
+                )
+                .expect("could not insert history value");
+            }
+        }
+
+        #[test]
+        fn reads_recent_history_from_application_shared_storage_first() {
+            let root = temp_dir("shared-first");
+            let shared = root.join("shared").join("state.vscdb");
+            let legacy = root.join("legacy").join("state.vscdb");
+
+            create_history_db(
+                &shared,
+                Some(json!({
+                    "entries": [{
+                        "folderUri": "file:///tmp/shared-project",
+                        "label": "Shared Project"
+                    }]
+                })),
+            );
+            create_history_db(
+                &legacy,
+                Some(json!({
+                    "entries": [{
+                        "folderUri": "file:///tmp/legacy-project",
+                        "label": "Legacy Project"
+                    }]
+                })),
+            );
+
+            let entries = get_history_entries_from_state_db_paths(
+                &[
+                    candidate("application shared storage", shared),
+                    candidate("legacy global storage", legacy),
+                ],
+                false,
+            )
+            .expect("expected entries");
+
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].label().unwrap(), "Shared Project");
+
+            fs::remove_dir_all(root).ok();
+        }
+
+        #[test]
+        fn falls_back_to_legacy_storage_when_shared_key_is_missing() {
+            let root = temp_dir("legacy-fallback");
+            let shared = root.join("shared").join("state.vscdb");
+            let legacy = root.join("legacy").join("state.vscdb");
+
+            create_history_db(&shared, None);
+            create_history_db(
+                &legacy,
+                Some(json!({
+                    "entries": [{
+                        "folderUri": "file:///tmp/legacy-project",
+                        "label": "Legacy Project"
+                    }]
+                })),
+            );
+
+            let entries = get_history_entries_from_state_db_paths(
+                &[
+                    candidate("application shared storage", shared),
+                    candidate("legacy global storage", legacy),
+                ],
+                false,
+            )
+            .expect("expected legacy fallback entries");
+
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].label().unwrap(), "Legacy Project");
+
+            fs::remove_dir_all(root).ok();
+        }
+
+        #[test]
+        fn stores_recent_history_in_shared_storage_with_upsert() {
+            let root = temp_dir("shared-upsert");
+            let shared = root.join("shared").join("state.vscdb");
+            let legacy = root.join("legacy").join("state.vscdb");
+
+            create_history_db(&shared, None);
+            create_history_db(
+                &legacy,
+                Some(json!({
+                    "entries": [{
+                        "folderUri": "file:///tmp/legacy-project",
+                        "label": "Legacy Project"
+                    }]
+                })),
+            );
+
+            let recent: Recent = serde_json::from_value(json!({
+                "folderUri": "file:///tmp/new-project",
+                "label": "New Project"
+            }))
+            .expect("could not deserialize recent");
+
+            store_history_entries_to_state_db_paths(
+                &[
+                    candidate("application shared storage", shared.clone()),
+                    candidate("legacy global storage", legacy),
+                ],
+                &[recent],
+            )
+            .expect("could not store entries");
+
+            let conn = Connection::open(shared).expect("could not reopen shared db");
+            let stored: serde_json::Value = conn
+                .query_row(
+                    "SELECT value FROM ItemTable WHERE key = (?1)",
+                    [VSCDB_HISTORY_KEY],
+                    |row| row.get(0),
+                )
+                .expect("could not read stored history");
+
+            assert_eq!(stored["entries"][0]["label"], "New Project");
+
+            fs::remove_dir_all(root).ok();
+        }
 
         #[test]
         fn local_workspace_properties() {
@@ -627,15 +844,108 @@ pub mod workspaces {
     }
 }
 
-fn open_state_db(config_dir: &Path, open_flags: Option<OpenFlags>) -> anyhow::Result<Connection> {
-    let open_flags = open_flags.unwrap_or_default();
-    let db_path = config_dir
-        .join("User")
-        .join("globalStorage")
-        .join("state.vscdb");
+fn history_state_db_paths(config_dir: &Path, flavor: &Flavor) -> Vec<StateDbPath> {
+    let mut paths = flavor
+        .shared_state_db_paths()
+        .into_iter()
+        .map(|path| StateDbPath {
+            scope: "application shared storage",
+            path,
+        })
+        .collect::<Vec<_>>();
 
-    Connection::open_with_flags(&db_path, open_flags)
-        .with_context(|| format!("Could not open database {:?}", &db_path))
+    paths.push(StateDbPath {
+        scope: "legacy global storage",
+        path: config_dir
+            .join("User")
+            .join("globalStorage")
+            .join("state.vscdb"),
+    });
+
+    paths
+}
+
+fn open_history_state_db(
+    candidates: &[StateDbPath],
+    open_flags: Option<OpenFlags>,
+    require_history_key: bool,
+) -> anyhow::Result<Connection> {
+    let open_flags = open_flags.unwrap_or_default();
+    let mut attempts = Vec::new();
+
+    for candidate in candidates {
+        let conn = match Connection::open_with_flags(&candidate.path, open_flags) {
+            Ok(conn) => conn,
+            Err(error) => {
+                attempts.push(format!(
+                    "{} {:?}: could not open ({error})",
+                    candidate.scope, candidate.path
+                ));
+                continue;
+            }
+        };
+
+        match item_table_exists(&conn) {
+            Ok(true) => {}
+            Ok(false) => {
+                attempts.push(format!(
+                    "{} {:?}: ItemTable not found",
+                    candidate.scope, candidate.path
+                ));
+                continue;
+            }
+            Err(error) => {
+                attempts.push(format!(
+                    "{} {:?}: could not inspect schema ({error})",
+                    candidate.scope, candidate.path
+                ));
+                continue;
+            }
+        }
+
+        if require_history_key {
+            match history_key_exists(&conn) {
+                Ok(true) => {}
+                Ok(false) => {
+                    attempts.push(format!(
+                        "{} {:?}: key {VSCDB_HISTORY_KEY:?} not found",
+                        candidate.scope, candidate.path
+                    ));
+                    continue;
+                }
+                Err(error) => {
+                    attempts.push(format!(
+                        "{} {:?}: could not inspect history key ({error})",
+                        candidate.scope, candidate.path
+                    ));
+                    continue;
+                }
+            }
+        }
+
+        return Ok(conn);
+    }
+
+    Err(anyhow!(
+        "Could not open VSCode history state DB. Tried: {}",
+        attempts.join("; ")
+    ))
+}
+
+fn item_table_exists(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'ItemTable')",
+        [],
+        |row| row.get::<_, bool>(0),
+    )
+}
+
+fn history_key_exists(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM ItemTable WHERE key = (?1))",
+        [VSCDB_HISTORY_KEY],
+        |row| row.get::<_, bool>(0),
+    )
 }
 
 /// Replace the home directory prefix of `path` with `~`


### PR DESCRIPTION
## Summary

- Prefer VS Code 1.118 application shared storage when reading recent folders/files.
- Fall back to the legacy User/globalStorage state database for older VS Code releases or unmigrated keys.
- Use INSERT OR REPLACE when storing recent entries so deletion can materialize the shared-storage key.
- Document the new Linux stable VS Code shared DB path.

## Root cause

VS Code 1.118 stores history.recentlyOpenedPathsList in StorageScope.APPLICATION_SHARED. For stable VS Code on Linux, that resolves to ~/.vscode-shared/sharedStorage/state.vscdb, while this project only opened ~/.config/Code/User/globalStorage/state.vscdb.

## Validation

- cargo fmt --check
- cargo test --no-default-features
- cargo test
- cargo clippy --all-targets -- -D warnings
- target/debug/vscode-recent -c code -F uri > /tmp/rofi-vscode-recent-uris.txt (read 130 local VS Code recent entries from this machine)
